### PR TITLE
Deal with namespaced commanders

### DIFF
--- a/lib/javascript/fie/cable.js
+++ b/lib/javascript/fie/cable.js
@@ -6,8 +6,12 @@ import { camelize } from 'humps';
 export class Cable {
   constructor() {
     const connectionUUID = uuid();
-    let commanderName = `${ camelize(this._controllerName) }Commander`;
-    commanderName = commanderName.charAt(0).toUpperCase() + commanderName.slice(1);
+
+    let commanderName = this._controllerName.split('/').map(p => {
+      p = `${ camelize(p) }`;
+      p = p.charAt(0).toUpperCase() + p.slice(1);
+      return p;
+    }).join('::').concat('Commander');
 
     this.commander = new Commander(commanderName, connectionUUID, this);
     this.pools = {};

--- a/lib/javascript/fie/cable.js
+++ b/lib/javascript/fie/cable.js
@@ -7,10 +7,10 @@ export class Cable {
   constructor() {
     const connectionUUID = uuid();
 
-    let commanderName = this._controllerName.split('/').map(p => {
-      p = `${ camelize(p) }`;
-      p = p.charAt(0).toUpperCase() + p.slice(1);
-      return p;
+    let commanderName = this._controllerName.split('/').map(commanderNamePart => {
+      commanderNamePart = `${ camelize(commanderNamePart) }`;
+      commanderNamePart = commanderNamePart.charAt(0).toUpperCase() + commanderNamePart.slice(1);
+      return commanderNamePart;
     }).join('::').concat('Commander');
 
     this.commander = new Commander(commanderName, connectionUUID, this);


### PR DESCRIPTION
We needed a commander for a controller in admin folder (module).
Fie was turning this into Admin/samplesCommander, while it should be Admin::SamplesCommander

This pull request fixes that.