### PR TITLE
Fixed encoding issues in pools, removed dependencies, and upgraded to version 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## Released
 
+### 0.3.6
+- Fixed encoding issue in pools
+- Removed unnecessary dependencies
+
 ### 0.3.5
 
 - Fixed security vulnerabilities

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,7 @@
 PATH
   remote: .
   specs:
-    fie (0.3.5)
-      rails (~> 5.2, >= 5.2.0)
-      railties (~> 5.2, >= 5.2.0)
-      redis (~> 4.0, >= 4.0.1)
+    fie (0.3.6)
 
 GEM
   remote: https://rubygems.org/
@@ -71,7 +68,7 @@ GEM
     factory_bot_rails (4.10.0)
       factory_bot (~> 4.10.0)
       railties (>= 3.0.0)
-    globalid (0.4.1)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
@@ -84,7 +81,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
-    mimemagic (0.3.2)
+    mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -124,7 +121,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.5.0)
-    redis (4.0.3)
+    redis (4.1.0)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -175,8 +172,11 @@ DEPENDENCIES
   factory_bot_rails (~> 4.10.0, >= 4.10.0)
   fie!
   pry-rails (~> 0.3.6, >= 0.3.6)
+  rails (~> 5.2, >= 5.2.0)
+  railties (~> 5.2, >= 5.2.0)
   rake (~> 10.0, >= 10.0)
+  redis (~> 4.0, >= 4.0.1)
   rspec-rails (~> 3.7, >= 3.7)
 
 BUNDLED WITH
-   1.16.4
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ fie therefore replaces traditional Javascript frontend frameworks while requirin
 1. Add the gem to your gemfile like so:
 
 ```ruby
-gem 'fie', '~> 0.3.5'
+gem 'fie', '~> 0.3.6'
 ```
 
 2. Run the bundler

--- a/fie.gemspec
+++ b/fie.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'action-cable-testing', '~> 0.3.1', '>= 0.3.1'
   spec.add_development_dependency 'coveralls', '~> 0.8.21', '>= 0.8.21'
   spec.add_development_dependency 'pry-rails', '~> 0.3.6', '>= 0.3.6'
-  spec.add_runtime_dependency 'redis', '~> 4.0', '>= 4.0.1'
-  spec.add_runtime_dependency 'rails', '~> 5.2', '>= 5.2.0'
-  spec.add_runtime_dependency 'railties', '~> 5.2', '>= 5.2.0'
+  spec.add_development_dependency 'redis', '~> 4.0', '>= 4.0.1'
+  spec.add_development_dependency 'rails', '~> 5.2', '>= 5.2.0'
+  spec.add_development_dependency 'railties', '~> 5.2', '>= 5.2.0'
 end

--- a/lib/fie/pools.rb
+++ b/lib/fie/pools.rb
@@ -15,7 +15,7 @@ module Fie
           command: 'publish_to_pool_lazy',
           parameters: {
             subject: subject,
-            object: Marshal.dump(object)
+            object: Marshal.dump(object).force_encoding(Encoding::UTF_8)
           }
       end
 
@@ -25,7 +25,7 @@ module Fie
           command: 'publish_to_pool',
           parameters: {
             subject: subject,
-            object: Marshal.dump(object),
+            object: Marshal.dump(object).force_encoding(Encoding::UTF_8),
             sender_uuid: sender_uuid
           }
       end

--- a/lib/fie/version.rb
+++ b/lib/fie/version.rb
@@ -1,3 +1,3 @@
 module Fie
-  VERSION = '0.3.5'
+  VERSION = '0.3.6'
 end


### PR DESCRIPTION
The main reason for this PR is to fix encoding issues in `pools` that would not allow objects with special characters such as `é` to be published.

Secondly, unnecessary runtime dependencies to `rails` and `redis` were removed to make fie more flexible.