### PR TITLE
Redis.new replaced with ActionCable.server.pubsub.redis_connection_fo…

### DIFF
--- a/lib/fie/commander.rb
+++ b/lib/fie/commander.rb
@@ -1,9 +1,11 @@
 require 'fie/state'
 require 'fie/pools'
-require 'redis'
+require 'fie/helper'
 
 module Fie
   class Commander < ActionCable::Channel::Base
+    include Fie::Helper
+
     @@pools_subjects = Set.new
     @@disable_override = false
 
@@ -17,7 +19,7 @@ module Fie
         controller_name: params['controller_name'],
         action_name: params['action_name'],
         uuid: self.params[:identifier]
-      
+
       execute_js_function('Fie.triggerFieReadyEvent')
     end
 
@@ -66,10 +68,6 @@ module Fie
     end
 
     private
-      def redis
-        $redis ||= Redis.new
-      end
-
       def method_keywords_hash(method_name, params)
         method(method_name).parameters.map do |_, parameter_name|
           [parameter_name, params[parameter_name.to_s]]
@@ -102,7 +100,7 @@ module Fie
       def method_added(name)
         super_commander_method_names = [
           :subscribed,
-          :refresh_view, 
+          :refresh_view,
           :identifier,
           :state,
           :unsubscribed,
@@ -129,7 +127,7 @@ module Fie
             if caller = params['caller']
               @caller = { value: caller['value'], id: caller['id'], class: caller['class'] }
             end
-            
+
             @controller_name = params['controller_name']
             @action_name = params['action_name']
             @connection_uuid = self.params['identifier']

--- a/lib/fie/helper.rb
+++ b/lib/fie/helper.rb
@@ -1,0 +1,11 @@
+module Fie
+  module Helper
+    def redis
+      @redis ||= if ENV['REDIS_URL']
+        Redis.new
+      else
+        ActionCable.server.pubsub.redis_connection_for_subscriptions.dup
+      end
+    end
+  end
+end

--- a/lib/fie/manipulator.rb
+++ b/lib/fie/manipulator.rb
@@ -1,8 +1,10 @@
 require 'fie/commander_closed'
-require 'redis'
+require 'fie/helper'
 
 module Fie
   module Manipulator
+    include Fie::Helper
+
     def state
       commander_name = Commander.commander_name(@fie_connection_uuid)
 
@@ -31,10 +33,5 @@ module Fie
       commander_name = Commander.commander_name(@fie_connection_uuid)
       !redis.get(commander_name).nil?
     end
-
-    private
-      def redis
-        $redis ||= Redis.new
-      end
   end
 end

--- a/spec/fie/helper_spec.rb
+++ b/spec/fie/helper_spec.rb
@@ -1,0 +1,26 @@
+class HelperTestClass
+  include Fie::Helper
+end
+
+RSpec.describe Fie::Helper do
+  describe '#redis' do
+    subject{ HelperTestClass.new }
+    context 'when ENV["REDIS_URL"] is present' do
+      it do
+        allow(ENV).to receive(:[]).with("REDIS_URL").and_return("redis://")
+        allow(Redis).to receive(:new).and_return('success_env')
+        expect(subject.redis).to be_eql('success_env')
+      end
+    end
+
+    context 'when ENV["REDIS_URL"] is absent' do
+      it do
+        allow(ENV).to receive(:[]).with("REDIS_URL").and_return(nil)
+        allow(ActionCable).to receive_message_chain(
+          :server, :pubsub, :redis_connection_for_subscriptions
+        ).and_return('success_without_env')
+        expect(subject.redis).to be_eql('success_without_env')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change seems to be useful in case when ActionCable is configured without REDIS_URL.

For example, config/cable.yml:
```
redis: &redis
  adapter: redis
  url: redis://192.168.1.1/1

development:
  <<: *redis
  channel_prefix: app1_development

test:
  <<: *redis
  channel_prefix: app1_test

production:
  <<: *redis
  channel_prefix: app1_production
```